### PR TITLE
Fix 409 Conflict

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -2,6 +2,7 @@
     <default-field :field="field" :errors="errors">
         <template slot="field">
             <image-viewer
+                @image-deleted="imageDeleted"
                 v-show="!imgSrc"
                 :field="field"
                 :resourceId="resourceId"
@@ -135,6 +136,14 @@ export default {
                     alert('Sorry, FileReader API not supported')
                 }
             }
+        },
+
+        /**
+         * Inform the parent component that the file has been deleted
+         * This event allows to update the `lastRetrievedAt` timestamp for further model changes
+         */
+        imageDeleted() {
+            this.$emit('file-deleted')
         },
     },
 

--- a/resources/js/components/Image/ImageViewer.vue
+++ b/resources/js/components/Image/ImageViewer.vue
@@ -99,7 +99,7 @@ export default {
                 await Nova.request().delete(uri)
                 this.closeRemoveModal()
                 this.deleted = true
-                this.$emit('file-deleted')
+                this.$emit('image-deleted')
             } catch (error) {
                 this.closeRemoveModal()
 


### PR DESCRIPTION
Fixes #3 

When an image is deleted from the form, no submit can be performed afterwards because the `lastRetrievedAt` variable was not up to date.