### PR TITLE
fix: file field inheritance

### DIFF
--- a/src/AdvancedImage.php
+++ b/src/AdvancedImage.php
@@ -3,56 +3,19 @@
 namespace Ctessier\NovaAdvancedImageField;
 
 use Illuminate\Support\Facades\Storage;
-use Intervention\Image\Facades\Image;
 use Laravel\Nova\Fields\File;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 class AdvancedImage extends File
 {
+    use TransformableImage;
+
     /**
      * The field's component.
      *
      * @var string
      */
     public $component = 'advanced-image-field';
-
-    /**
-     * The driver library to use for image manipulation.
-     *
-     * This value will override the driver configured for Intervention
-     * in the `config/image.php` file of the Laravel project.
-     *
-     * @var string|null
-     */
-    public $driver = null;
-
-    /**
-     * Indicates if the image is croppable.
-     *
-     * @var bool
-     */
-    public $croppable = false;
-
-    /**
-     * The fixed aspect ratio of the crop box.
-     *
-     * @var float
-     */
-    public $cropAspectRatio;
-
-    /**
-     * The width for the resizing of the image.
-     *
-     * @var int
-     */
-    public $width;
-
-    /**
-     * The height for the resizing of the image.
-     *
-     * @var int
-     */
-    public $height;
 
     /**
      * Indicates if the element should be shown on the index view.
@@ -83,63 +46,6 @@ class AdvancedImage extends File
     }
 
     /**
-     * Override the default driver to be used by Intervention for the image manipulation.
-     *
-     * @param string $driver
-     *
-     * @throws \Exception
-     *
-     * @return $this
-     */
-    public function driver(string $driver)
-    {
-        if (!in_array($driver, ['gd', 'imagick'])) {
-            throw new \Exception("The driver \"$driver\" is not a valid Intervention driver.");
-        }
-
-        $this->driver = $driver;
-
-        return $this;
-    }
-
-    /**
-     * Specify if the underlying image should be croppable.
-     * If a numeric value is given as a first parameter, it will be used to define a fixed aspect
-     * ratio for the crop box.
-     *
-     * @param mixed $param
-     *
-     * @return $this
-     */
-    public function croppable($param = true)
-    {
-        if (is_numeric($param)) {
-            $this->cropAspectRatio = $param;
-            $param = true;
-        }
-
-        $this->croppable = $param;
-
-        return $this;
-    }
-
-    /**
-     * Specify the size (width and height) the image should be resized to.
-     *
-     * @param int|null $width
-     * @param int|null $height
-     *
-     * @return $this
-     */
-    public function resize($width = null, $height = null)
-    {
-        $this->width = $width;
-        $this->height = $height;
-
-        return $this;
-    }
-
-    /**
      * Hydrate the given attribute on the model based on the incoming request.
      *
      * @param \Laravel\Nova\Http\Requests\NovaRequest $request
@@ -157,65 +63,11 @@ class AdvancedImage extends File
 
         $previousFileName = $model->{$attribute};
 
-        if (!$this->croppable && !$this->width && !$this->height) {
-            parent::fillAttribute($request, $requestAttribute, $model, $attribute);
-        } else {
-            if ($this->driver) {
-                Image::configure([
-                    'driver' => $this->driver,
-                ]);
-            }
-            $image = Image::make($request->{$this->attribute});
-            if ($this->croppable) {
-                $this->handleCrop($image, json_decode($request->{$this->attribute.'_data'}));
-            }
-            if ($this->width || $this->height) {
-                $this->handleResize($image, $this->width, $this->height);
-            }
+        $this->transformImage($request->{$this->attribute}, json_decode($request->{$this->attribute.'_data'}));
 
-            $image->stream();
-            if ($this->storagePath === '/') {
-                $fileName = $request->{$this->attribute}->hashName();
-            } else {
-                $fileName = trim($this->storagePath, '/').'/'.$request->{$this->attribute}->hashName();
-            }
-            Storage::disk($this->disk)->put($fileName, $image->__toString());
-            $image->destroy();
-
-            $model->{$attribute} = $fileName;
-        }
+        parent::fillAttribute($request, $requestAttribute, $model, $attribute);
 
         Storage::disk($this->disk)->delete($previousFileName);
-    }
-
-    /**
-     * Crop the uploaded image.
-     *
-     * @param \Intervention\Image\Image $image
-     * @param object                    $cropperData
-     *
-     * @return void
-     */
-    private function handleCrop($image, $cropperData)
-    {
-        $image->crop($cropperData->width, $cropperData->height, $cropperData->x, $cropperData->y);
-    }
-
-    /**
-     * Resize the uploaded image.
-     *
-     * @param \Intervention\Image\Image $image
-     * @param int|null                  $width
-     * @param int|null                  $height
-     *
-     * @return void
-     */
-    private function handleResize($image, $width, $height)
-    {
-        $image->resize($width, $height, function ($constraint) {
-            $constraint->upsize();
-            $constraint->aspectRatio();
-        });
     }
 
     /**

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Ctessier\NovaAdvancedImageField;
+
+use Illuminate\Http\UploadedFile;
+use Intervention\Image\Facades\Image;
+
+trait TransformableImage
+{
+    /**
+     * The driver library to use for transforming the image.
+     *
+     * This value will override the driver configured for Intervention
+     * in the `config/image.php` file of the Laravel project.
+     *
+     * @var string|null
+     */
+    private $driver = null;
+
+    /**
+     * Indicates if the image is croppable.
+     *
+     * @var bool
+     */
+    private $croppable = false;
+
+    /**
+     * The fixed aspect ratio of the crop box.
+     *
+     * @var float
+     */
+    private $cropAspectRatio;
+
+    /**
+     * The width for the resizing of the image.
+     *
+     * @var int
+     */
+    private $width;
+
+    /**
+     * The height for the resizing of the image.
+     *
+     * @var int
+     */
+    private $height;
+
+    /**
+     * The Intervention Image instance.
+     *
+     * @var \Intervention\Image\Image
+     */
+    private $image;
+
+    /**
+     * Override the default driver to be used by Intervention for the image manipulation.
+     *
+     * @param string $driver
+     *
+     * @throws \Exception
+     *
+     * @return $this
+     */
+    public function driver(string $driver)
+    {
+        if (!in_array($driver, ['gd', 'imagick'])) {
+            throw new \Exception("The driver \"$driver\" is not a valid Intervention driver.");
+        }
+
+        $this->driver = $driver;
+
+        return $this;
+    }
+
+    /**
+     * Specify if the underlying image should be croppable.
+     * If a numeric value is given as a first parameter, it will be used to define a fixed aspect
+     * ratio for the crop box.
+     *
+     * @param mixed $param
+     *
+     * @return $this
+     */
+    public function croppable($param = true)
+    {
+        if (is_numeric($param)) {
+            $this->cropAspectRatio = $param;
+            $param = true;
+        }
+
+        $this->croppable = $param;
+
+        return $this;
+    }
+
+    /**
+     * Specify the size (width and height) the image should be resized to.
+     *
+     * @param int|null $width
+     * @param int|null $height
+     *
+     * @return $this
+     */
+    public function resize($width = null, $height = null)
+    {
+        $this->width = $width;
+        $this->height = $height;
+
+        return $this;
+    }
+
+    /**
+     * Transform the uploaded file.
+     *
+     * @param \Illuminate\Http\UploadedFile $uploadedFile
+     * @param object|null                   $cropperData
+     *
+     * @return void
+     */
+    public function transformImage(UploadedFile $uploadedFile, $cropperData)
+    {
+        if (!$this->croppable && !$this->width && !$this->height) {
+            return;
+        }
+
+        $this->image = Image::make($uploadedFile->getPathName());
+
+        if ($this->croppable && $cropperData) {
+            $this->cropImage($cropperData);
+        }
+
+        if ($this->width || $this->height) {
+            $this->resizeImage();
+        }
+
+        $this->image->save();
+    }
+
+
+    /**
+     * Crop the image.
+     *
+     * @param object $cropperData
+     *
+     * @return void
+     */
+    private function cropImage(object $cropperData)
+    {
+        $this->image->crop($cropperData->width, $cropperData->height, $cropperData->x, $cropperData->y);
+    }
+
+    /**
+     * Resize the image.
+     *
+     * @return void
+     */
+    private function resizeImage()
+    {
+        $this->image->resize($this->width, $this->height, function ($constraint) {
+            $constraint->upsize();
+            $constraint->aspectRatio();
+        });
+    }
+}


### PR DESCRIPTION
The Nova Advanced Image Field is supposed to inherit from the Nova File field.

That means the following methods should be available:

- ✅ disk
- ❓ disableDownload
- 🔴 storeOriginalName
- 🔴 storeSize
- ❓ deletable
- ❓ prunable
- ❓ path
- 🔴 storeAs
- 🔴 store
- ❓ delete
- ❓ preview
- ❓ thumbnail
- ❓ acceptedTypes