### PR TITLE
[BUGFIX] Dont call filesystem delete with null

### DIFF
--- a/src/AdvancedImage.php
+++ b/src/AdvancedImage.php
@@ -67,7 +67,9 @@ class AdvancedImage extends Image
 
         parent::fillAttribute($request, $requestAttribute, $model, $attribute);
 
-        Storage::disk($this->disk)->delete($previousFileName);
+        if ($previousFileName !== null) {
+            Storage::disk($this->disk)->delete($previousFileName);
+        }
     }
 
     /**


### PR DESCRIPTION
Applications using Laravel 9 will use FlySystem 3. The delete methods of FlySystem 3 no longer allow null as an argument. The argument must be a string.

See: https://github.com/thephpleague/flysystem/blob/3.x/src/Filesystem.php#L82

This pr simply surrounds the delete call with an if statement, so it isn't called when the given argument is null. This happens when using Laravel 9 while creating a new resource using the AdvancedImage field.