### PR TITLE
[BUGFIX] Prevent float values from going into the crop function

### DIFF
--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -177,7 +177,7 @@ trait TransformableImage
      */
     private function cropImage(object $cropperData)
     {
-        $this->image->crop($cropperData->width, $cropperData->height, $cropperData->left, $cropperData->top);
+        $this->image->crop((int) $cropperData->width, (int) $cropperData->height, (int) $cropperData->left, (int) $cropperData->top);
     }
 
     /**


### PR DESCRIPTION
We ran into the issue that float values were passed to the crop function. This resulted in an error, as the crop function only wants integers. This PR fixes that. Below you can see the logged `$cropperData` that was passed into the `cropImage` function on our live environment.

```json
{
    "data": {
        "stdClass": {
            "width": 2012,
            "height": 1132,
            "left": 128,
            "top": 119.01869791425563
        }
    }
}
```

Error
```
crop() accepts only integer values as argument 4. {"userId":2,"exception":"[object] (Intervention\\Image\\Exception\\InvalidArgumentException(code: 0): crop() accepts only integer values as argument 4. at /home/user/domain.com/vendor/intervention/image/src/Intervention/Image/Commands/Argument.php:138) 
```