### PR TITLE
[BUGFIX] Allow cropperdata to be null

### DIFF
--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -144,7 +144,7 @@ trait TransformableImage
      *
      * @return void
      */
-    public function transformImage(UploadedFile $uploadedFile, object $cropperData)
+    public function transformImage(UploadedFile $uploadedFile, ?object $cropperData)
     {
         if (!$this->croppable && !$this->width && !$this->height) {
             return;


### PR DESCRIPTION
If the cropper is disabled, the cropperdata will be null. The docblock above the method also says that it can be null, but the method signature doesnt allow null.

```
[2023-01-12 10:02:25] local.ERROR: Ctessier\NovaAdvancedImageField\AdvancedImage::transformImage(): Argument #2 ($cropperData) must be of type object, null given, called in /var/www/html/vendor/ctessier/nova-advanced-image-field/src/AdvancedImage.php on line 59 {"userId":1,"exception":"[object] (TypeError(code: 0): Ctessier\\NovaAdvancedImageField\\AdvancedImage::transformImage(): Argument #2 ($cropperData) must be of type object, null given, called in /var/www/html/vendor/ctessier/nova-advanced-image-field/src/AdvancedImage.php on line 59 at /var/www/html/vendor/ctessier/nova-advanced-image-field/src/TransformableImage.php:147)
[stacktrace]
```