### PR TITLE
Fix for DropZone update in Nova 4.22.0

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -45,6 +45,7 @@
         <DropZone
           v-if="shouldShowField"
           @change="handleFileChange"
+          @file-changed="handleFileChange"
           :files="field.croppable ? [] : files"
           @file-removed="removeFile"
           :rounded="field.rounded"


### PR DESCRIPTION
This fixes the broken DropZone integration in Nova 4.22.0 that stops the component from working.

It maintains backwards compatibility too for versions <4.22.0 by keeping the @change attribute too.