### PR TITLE
previousFileName to null for non-models

### DIFF
--- a/src/AdvancedImage.php
+++ b/src/AdvancedImage.php
@@ -54,7 +54,7 @@ class AdvancedImage extends Image
             return;
         }
 
-        $previousFileName = $model->{$attribute};
+        $previousFileName = $model->{$attribute} ?? null;
 
         $this->transformImage($request->{$this->attribute}, json_decode($request->{$this->attribute.'_data'}));
 


### PR DESCRIPTION
Hi,
Now it's needed that the AdvancedImage is added to a resource that's attached to a Model, but when you want to use it with this package: https://github.com/outl1ne/nova-settings  - there is not model. So as a default I added the previousFileName to null when this occurs.