### PR TITLE
Fix image transform on Windows server by forcing temporary path

### DIFF
--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -164,7 +164,7 @@ trait TransformableImage
             $this->resizeImage();
         }
 
-        $this->image->save();
+        $this->image->save($uploadedFile->getPathName(), 90, $uploadedFile->getClientOriginalExtension());
         $this->image->destroy();
     }
 


### PR DESCRIPTION
## Introduction 

This issue seems to occur when running PHP on a Windows server.
This pull requests fixes #52, fixes #72, fixes #92, fixes #100, fixes #101 

## Error

Intervention throws `Encoding format (tmp) is not supported.`
This happens because the package uses the Laravel's UploadedFile directly when doing the crop/resize transformation. It tries to save it after the transformation and before passing it onto Laravel for final storage. But at this point, the UploadedFile is still in a temp folder.
On Windows, it seems that Intervention struggles to determine the file's extension and uses `tmp`, which fails.

## Solution

Forcing the extension using the one from the UploadedFile seems to work.
This pull requests therefore provides parameters to the Intervention's `save` method to specify the full path (even though it's still the temp one) and most importantly, the extension.
