### PR TITLE
Added new method for intervention WebP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ This can be mandatory in some cases for the cropper to work properly.
 AdvancedImage::make('Photo')->autoOrientate(),
 ```
 
+_Note: PHP must be compiled in with `--enable-exif` to use this method. Windows users must also have the mbstring extension enabled. See [the Intervention Image documentation](https://image.intervention.io/v2/api/orientate) for more details._
+
 ### `webp()`
 
 Specify if the underlying image should be encoded and formatted to the webp format.
@@ -126,7 +128,7 @@ Specify if the underlying image should be encoded and formatted to the webp form
 AdvancedImage::make('Photo')->webp(),
 ```
 
-_Note: PHP must be compiled in with `--enable-exif` to use this method. Windows users must also have the mbstring extension enabled. See [the Intervention Image documentation](https://image.intervention.io/v2/api/orientate) for more details._
+_Note: For WebP support GD driver must be used with PHP 5 >= 5.5.0 or PHP 7 in order to use imagewebp(). If Imagick is used, it must be compiled with libwebp for WebP support._
 
 ### `quality(int $quality)`
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ Specify the desired output image format.
 AdvancedImage::make('Photo')->convert('webp'),
 ```
 
-_Note 1: To see all the supported formats that can be used to convert your files see [Intervention Image `encode()`]:(https://image.intervention.io/v2/api/encode_
-_Note 2: For WebP support GD driver must be used with PHP 5 >= 5.5.0 or PHP 7 in order to use imagewebp(). If Imagick is used, it must be compiled with libwebp for WebP support._
+_Note: _
+
+- _To see all the supported formats that can be used to convert your files see [Intervention Image `encode()`]:(https://image.intervention.io/v2/api/encode._
+- _For WebP support GD driver must be used with PHP 5 >= 5.5.0 or PHP 7 in order to use imagewebp(). If Imagick is used, it must be compiled with libwebp for WebP support._
 
 ### `quality(int $quality)`
 

--- a/README.md
+++ b/README.md
@@ -122,13 +122,16 @@ _Note: PHP must be compiled in with `--enable-exif` to use this method. Windows 
 
 ### `webp()`
 
-Specify if the underlying image should be encoded and formatted to the webp format.
+Specify the desired output image format.
 
 ```php
-AdvancedImage::make('Photo')->webp(),
+AdvancedImage::make('Photo')->convert('webp'),
 ```
 
-_Note: For WebP support GD driver must be used with PHP 5 >= 5.5.0 or PHP 7 in order to use imagewebp(). If Imagick is used, it must be compiled with libwebp for WebP support._
+\_Note:
+
+1. To see all the supported formats that can be used to convert your files see [Intervention Image `encode()`]:(https://image.intervention.io/v2/api/encode
+2. For WebP support GD driver must be used with PHP 5 >= 5.5.0 or PHP 7 in order to use imagewebp(). If Imagick is used, it must be compiled with libwebp for WebP support.\_
 
 ### `quality(int $quality)`
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ AdvancedImage::make('Photo')->autoOrientate(),
 
 _Note: PHP must be compiled in with `--enable-exif` to use this method. Windows users must also have the mbstring extension enabled. See [the Intervention Image documentation](https://image.intervention.io/v2/api/orientate) for more details._
 
-### `webp()`
+### `convert(string $format)`
 
 Specify the desired output image format.
 
@@ -128,10 +128,8 @@ Specify the desired output image format.
 AdvancedImage::make('Photo')->convert('webp'),
 ```
 
-\_Note:
-
-1. To see all the supported formats that can be used to convert your files see [Intervention Image `encode()`]:(https://image.intervention.io/v2/api/encode
-2. For WebP support GD driver must be used with PHP 5 >= 5.5.0 or PHP 7 in order to use imagewebp(). If Imagick is used, it must be compiled with libwebp for WebP support.\_
+_Note 1: To see all the supported formats that can be used to convert your files see [Intervention Image `encode()`]:(https://image.intervention.io/v2/api/encode_
+_Note 2: For WebP support GD driver must be used with PHP 5 >= 5.5.0 or PHP 7 in order to use imagewebp(). If Imagick is used, it must be compiled with libwebp for WebP support._
 
 ### `quality(int $quality)`
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ AdvancedImage::make('Photo')->resize(600, 400),
 AdvancedImage::make('Photo')->resize(null, 300),
 ```
 
-*Note: this method uses [Intervention Image `resize()`](https://image.intervention.io/v2/api/resize) with the upsize and aspect ratio constraints.*
+_Note: this method uses [Intervention Image `resize()`](https://image.intervention.io/v2/api/resize) with the upsize and aspect ratio constraints._
 
 ### `autoOrientate()`
 
@@ -118,7 +118,15 @@ This can be mandatory in some cases for the cropper to work properly.
 AdvancedImage::make('Photo')->autoOrientate(),
 ```
 
-*Note: PHP must be compiled in with `--enable-exif` to use this method. Windows users must also have the mbstring extension enabled. See [the Intervention Image documentation](https://image.intervention.io/v2/api/orientate) for more details.*
+### `webp()`
+
+Specify if the underlying image should be encoded and formatted to the webp format.
+
+```php
+AdvancedImage::make('Photo')->webp(),
+```
+
+_Note: PHP must be compiled in with `--enable-exif` to use this method. Windows users must also have the mbstring extension enabled. See [the Intervention Image documentation](https://image.intervention.io/v2/api/orientate) for more details._
 
 ### `quality(int $quality)`
 
@@ -130,4 +138,4 @@ This only applies to JPG format as PNG compression is lossless. The value must r
 AdvancedImage::make('Photo')->resize(600, 400)->quality(95),
 ```
 
-*Note: the quality will be passed to the [Intervention Image `save()`](https://image.intervention.io/v2/api/save) method.*
+_Note: the quality will be passed to the [Intervention Image `save()`](https://image.intervention.io/v2/api/save) method._

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -186,10 +186,8 @@ trait TransformableImage
             throw new \Exception("Unsupported output format: $format");
         }
         
-        
         $this->outputFormat = $format;
-
-
+        
         return $this;
     }
 

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -97,6 +97,8 @@ trait TransformableImage
      */
     public function croppable($param = true)
     {
+        throw new \Exception("Test exception");
+
         if (is_numeric($param)) {
             $this->cropAspectRatio = $param;
             $param = true;

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -173,19 +173,19 @@ trait TransformableImage
     }
 
     /**
-     * Specify the image format.
-     * This only applies to formats that are supported by Intervention.
+     * Specify the desired output image format.
+     * This method sets the output format to be used by Intervention.
      *
      * @throws \Exception
      *
      * @return $this
      */
-    public function convert($format) 
+    public function convert($format)
     {
         if (!in_array($format, $this->allowedExtensions)) {
             throw new \Exception("Unsupported output format: $format");
         }
-    
+        
         $this->outputFormat = $format;
     
         return $this;

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -64,7 +64,9 @@ trait TransformableImage
      *
      * @var bool
      */
-    private $webp = false;
+    private $outputFormat;
+
+    private $allowedExtensions = ['jpg', 'png', 'gif', 'tif', 'bmp', 'ico', 'psd', 'webp', 'data-url'];
 
     /**
      * The Intervention Image instance.
@@ -170,15 +172,14 @@ trait TransformableImage
         return $this;
     }
 
-    /**
-     * Specify if the underlying image should be encoded to the webp format.
-     *
-     * @return $this
-     */
-    public function webp()
+    public function convert($format) 
     {
-        $this->webp = true;
-
+        if (!in_array($format, $this->$allowedExtensions)) {
+            throw new \Exception("Unsupported output format: $format");
+        }
+    
+        $this->outputFormat = $format;
+    
         return $this;
     }
 
@@ -210,11 +211,11 @@ trait TransformableImage
             $this->resizeImage();
         }
 
-        if ($this->webp) {
-            $this->convertToWebp();
+        if ($this->outputFormat) {
+            $this->convertImage($this->outputFormat);
         }
 
-        $this->image->save($uploadedFile->getPathName(), $this->quality, $this->webp === true ? 'webp' : $uploadedFile->getClientOriginalExtension());
+        $this->image->save($uploadedFile->getPathName(), $this->quality, $this->outputFormat ? $this->outputFormat : $uploadedFile->getClientOriginalExtension());
         $this->image->destroy();
     }
 
@@ -254,12 +255,12 @@ trait TransformableImage
     }
 
     /**
-     * Encodes the image to a webp format.
+     * Encodes the image to the given format.
      *
      * @return void
      */
-    private function convertToWebp()
+    private function convertImage($format)
     {
-        $this->image->encode('webp');
+        $this->image->encode($format);
     }
 }

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -181,10 +181,6 @@ trait TransformableImage
      */
     public function webp()
     {
-        // if (!extension_loaded('exif')) {
-        //     throw new \Exception('The PHP exif extension must be enabled to use the autoOrientate method.');
-        // }
-
         $this->webp = true;
 
         return $this;
@@ -219,7 +215,7 @@ trait TransformableImage
         }
 
         if($this->webp) {
-            $this->covertToWebp();
+            $this->convertToWebp();
         }
 
         $this->image->save($uploadedFile->getPathName(), $this->quality, $uploadedFile->getClientOriginalExtension());
@@ -266,7 +262,7 @@ trait TransformableImage
      *
      * @return void
      */
-    private function covertToWebp() {
+    private function convertToWebp() {
         $this->image->encode('webp');
     }
 }

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -185,9 +185,9 @@ trait TransformableImage
         if (!in_array($format, $this->allowedExtensions)) {
             throw new \Exception("Unsupported output format: $format");
         }
-        
+
         $this->outputFormat = $format;
-        
+
         return $this;
     }
 

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -186,8 +186,10 @@ trait TransformableImage
             throw new \Exception("Unsupported output format: $format");
         }
         
+        
         $this->outputFormat = $format;
-    
+
+
         return $this;
     }
 

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -171,11 +171,7 @@ trait TransformableImage
     }
 
     /**
-     * Specify if the underlying image should be orientated.
-     * Rotate the image to the orientation specified in Exif data, if any. Especially useful for smartphones.
-     * This method requires the exif extension to be enabled in your php settings.
-     *
-     * @throws \Exception
+     * Specify if the underlying image should be encoded to the webp format.
      *
      * @return $this
      */
@@ -214,7 +210,7 @@ trait TransformableImage
             $this->resizeImage();
         }
 
-        if($this->webp) {
+        if ($this->webp) {
             $this->convertToWebp();
         }
 
@@ -262,7 +258,8 @@ trait TransformableImage
      *
      * @return void
      */
-    private function convertToWebp() {
+    private function convertToWebp()
+    {
         $this->image->encode('webp');
     }
 }

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -172,9 +172,17 @@ trait TransformableImage
         return $this;
     }
 
+    /**
+     * Specify the image format.
+     * This only applies to formats that are supported by Intervention.
+     *
+     * @throws \Exception
+     *
+     * @return $this
+     */
     public function convert($format) 
     {
-        if (!in_array($format, $this->$allowedExtensions)) {
+        if (!in_array($format, $this->allowedExtensions)) {
             throw new \Exception("Unsupported output format: $format");
         }
     

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -60,18 +60,11 @@ trait TransformableImage
     private $quality = 90;
 
     /**
-     * Indicates if the image is croppable.
+     * The format of the resulting image.
      *
-     * @var bool
+     * @var string
      */
     private $outputFormat;
-
-    /**
-     * Indicates the allowed extensions for the output format.
-     *
-     * @var array
-     */
-    private $allowedExtensions = ['jpg', 'png', 'gif', 'tif', 'bmp', 'ico', 'psd', 'webp', 'data-url'];
 
     /**
      * The Intervention Image instance.
@@ -185,9 +178,12 @@ trait TransformableImage
      *
      * @return $this
      */
-    public function convert($format)
+    public function convert(string $format)
     {
-        if (!in_array($format, $this->allowedExtensions)) {
+        /**
+         * @See https://image.intervention.io/v2/api/encode
+         */
+        if (!in_array($format, ['jpg', 'png', 'gif', 'tif', 'bmp', 'ico', 'psd', 'webp', 'data-url'])) {
             throw new \Exception("Unsupported output format: $format");
         }
 
@@ -228,7 +224,7 @@ trait TransformableImage
             $this->convertImage($this->outputFormat);
         }
 
-        $this->image->save($uploadedFile->getPathName(), $this->quality, $this->outputFormat ? $this->outputFormat : $uploadedFile->getClientOriginalExtension());
+        $this->image->save($uploadedFile->getPathName(), $this->quality, $this->outputFormat ?? $uploadedFile->getClientOriginalExtension());
         $this->image->destroy();
     }
 
@@ -268,12 +264,12 @@ trait TransformableImage
     }
 
     /**
-     * Encodes the image to the given format.
+     * Encode the image to the given format.
      *
      * @return void
      */
-    private function convertImage($format)
+    private function convertImage(string $format)
     {
-        $this->image->encode($format);
+        $this->image->encode($format, $this->quality);
     }
 }

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -66,6 +66,11 @@ trait TransformableImage
      */
     private $outputFormat;
 
+    /**
+     * Indicates the allowed extensions for the output format.
+     *
+     * @var array
+     */
     private $allowedExtensions = ['jpg', 'png', 'gif', 'tif', 'bmp', 'ico', 'psd', 'webp', 'data-url'];
 
     /**

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -97,8 +97,6 @@ trait TransformableImage
      */
     public function croppable($param = true)
     {
-        throw new \Exception("Test exception");
-
         if (is_numeric($param)) {
             $this->cropAspectRatio = $param;
             $param = true;

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -60,6 +60,13 @@ trait TransformableImage
     private $quality = 90;
 
     /**
+     * Indicates if the image is croppable.
+     *
+     * @var bool
+     */
+    private $webp = false;
+
+    /**
      * The Intervention Image instance.
      *
      * @var \Intervention\Image\Image
@@ -164,6 +171,26 @@ trait TransformableImage
     }
 
     /**
+     * Specify if the underlying image should be orientated.
+     * Rotate the image to the orientation specified in Exif data, if any. Especially useful for smartphones.
+     * This method requires the exif extension to be enabled in your php settings.
+     *
+     * @throws \Exception
+     *
+     * @return $this
+     */
+    public function webp()
+    {
+        // if (!extension_loaded('exif')) {
+        //     throw new \Exception('The PHP exif extension must be enabled to use the autoOrientate method.');
+        // }
+
+        $this->webp = true;
+
+        return $this;
+    }
+
+    /**
      * Transform the uploaded file.
      *
      * @param \Illuminate\Http\UploadedFile $uploadedFile
@@ -189,6 +216,10 @@ trait TransformableImage
 
         if ($this->width || $this->height) {
             $this->resizeImage();
+        }
+
+        if($this->webp) {
+            $this->covertToWebp();
         }
 
         $this->image->save($uploadedFile->getPathName(), $this->quality, $uploadedFile->getClientOriginalExtension());
@@ -228,5 +259,14 @@ trait TransformableImage
     private function orientateImage()
     {
         $this->image->orientate();
+    }
+
+    /**
+     * Encodes the image to a webp format.
+     *
+     * @return void
+     */
+    private function covertToWebp() {
+        $this->image->encode('webp');
     }
 }

--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -218,7 +218,7 @@ trait TransformableImage
             $this->convertToWebp();
         }
 
-        $this->image->save($uploadedFile->getPathName(), $this->quality, $uploadedFile->getClientOriginalExtension());
+        $this->image->save($uploadedFile->getPathName(), $this->quality, $this->webp === true ? 'webp' : $uploadedFile->getClientOriginalExtension());
         $this->image->destroy();
     }
 


### PR DESCRIPTION
Hi @ctessier 

Hope you can find the time to check my PR and hopefully approve it. 

I hope I've implemented it the right way, if not please let me know so I can change it accordingly. Tested it locally worked as intended.

Its currently only limited to use `webp` and not for all the other possibly encodings [see.](https://image.intervention.io/v2/api/encode)

Fixes #106.